### PR TITLE
Add pointers to the new format

### DIFF
--- a/inctermsheet
+++ b/inctermsheet
@@ -1,0 +1,3 @@
+This term sheet is now available in Markdown:
+
+https://github.com/indievc/indievc/blob/master/inctermsheet.md

--- a/llctermsheet
+++ b/llctermsheet
@@ -1,0 +1,3 @@
+This term sheet is now available in Markdown:
+
+https://github.com/indievc/indievc/blob/master/llctermsheet.md


### PR DESCRIPTION
These should prevent people from getting dead links to the old term sheet format.
